### PR TITLE
Use context manager to avoid ResourceWarning

### DIFF
--- a/pyverilog/__init__.py
+++ b/pyverilog/__init__.py
@@ -3,4 +3,5 @@ from __future__ import print_function
 
 import os
 
-__version__ = open(os.path.join(os.path.dirname(__file__), "VERSION")).read().splitlines()[0]
+with open(os.path.join(os.path.dirname(__file__), "VERSION")) as f:
+    __version__ = f.read().splitlines()[0]


### PR DESCRIPTION
This implicitly will call close to avoid an unclosed file warning.